### PR TITLE
Fix mobile navigation and prevent zoom on form focus

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -807,7 +807,7 @@ function StepPanel({ step, stepIndex, total, onNext, onPrev, onProgressChange }:
             </div>
 
             {(subIndex === 0 || subIndex === 1) && (
-              <div className="flex justify-between mt-4">
+              <div className="sub-step-nav flex justify-between mt-4">
                 <button type="button" onClick={() => setSubIndex((s) => Math.max(0, s - 1))} disabled={subIndex === 0} className={`px-4 py-2 rounded-md ${subIndex === 0 ? 'bg-gray-100 text-gray-400' : 'bg-white border border-gray-300 text-gray-700'}`}>
                   Previous
                 </button>
@@ -968,7 +968,7 @@ function StepPanel({ step, stepIndex, total, onNext, onPrev, onProgressChange }:
             </div>
 
             {/* Sub-step navigation */}
-            <div className="flex justify-between mt-4">
+            <div className="sub-step-nav flex justify-between mt-4">
               <button type="button" onClick={() => setSubIndex((s) => Math.max(0, s - 1))} disabled={subIndex === 0} className={`px-4 py-2 rounded-md ${subIndex === 0 ? 'bg-gray-100 text-gray-400' : 'bg-white border border-gray-300 text-gray-700'}`}>
                 Previous
               </button>
@@ -1097,7 +1097,7 @@ function StepPanel({ step, stepIndex, total, onNext, onPrev, onProgressChange }:
             </div>
 
             {/* Sub-step navigation */}
-            <div className="flex justify-between mt-4">
+            <div className="sub-step-nav flex justify-between mt-4">
               <button type="button" onClick={() => setSubIndex((s) => Math.max(0, s - 1))} disabled={subIndex === 0} className={`px-4 py-2 rounded-md ${subIndex === 0 ? 'bg-gray-100 text-gray-400' : 'bg-white border border-gray-300 text-gray-700'}`}>
                 Previous
               </button>
@@ -1214,7 +1214,7 @@ function StepPanel({ step, stepIndex, total, onNext, onPrev, onProgressChange }:
             </div>
 
             {/* Sub-step navigation */}
-            <div className="flex justify-between mt-4">
+            <div className="sub-step-nav flex justify-between mt-4">
               <button type="button" onClick={() => setSubIndex((s) => Math.max(0, s - 1))} disabled={subIndex === 0} className={`px-4 py-2 rounded-md ${subIndex === 0 ? 'bg-gray-100 text-gray-400' : 'bg-white border border-gray-300 text-gray-700'}`}>
                 Previous
               </button>
@@ -1364,7 +1364,7 @@ function StepPanel({ step, stepIndex, total, onNext, onPrev, onProgressChange }:
 
             {/* Sub-step navigation (only on preview substep) */}
             {subIndex === 0 && (
-              <div className="flex justify-between mt-4">
+              <div className="sub-step-nav flex justify-between mt-4">
                 <button type="button" onClick={() => setSubIndex((s) => Math.max(0, s - 1))} disabled={subIndex === 0} className={`px-4 py-2 rounded-md ${subIndex === 0 ? 'bg-gray-100 text-gray-400' : 'bg-white border border-gray-300 text-gray-700'}`}>
                   Previous
                 </button>
@@ -1505,7 +1505,7 @@ function StepPanel({ step, stepIndex, total, onNext, onPrev, onProgressChange }:
             </div>
 
             {/* Sub-step navigation */}
-            <div className="flex justify-between mt-4">
+            <div className="sub-step-nav flex justify-between mt-4">
               <button type="button" onClick={() => setSubIndex((s) => Math.max(0, s - 1))} disabled={subIndex === 0} className={`px-4 py-2 rounded-md ${subIndex === 0 ? 'bg-gray-100 text-gray-400' : 'bg-white border border-gray-300 text-gray-700'}`}>
                 Previous
               </button>
@@ -1587,7 +1587,7 @@ export default function Home() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <main className="onboarding-container">
+      <main className={`onboarding-container ${showStepper ? 'stepper-active' : ''}`}>
         <div className="container">
           <div className="logo-container">
             <img

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1601,7 +1601,7 @@ export default function Home() {
       <Head>
         <title>CoachNova - Account Setup</title>
         <meta name="description" content="Set up your CoachNova account" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no, shrink-to-fit=no" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main className={`onboarding-container ${showStepper ? 'stepper-active' : ''}`}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import Head from 'next/head';
 
 type OnboardingFormProps = {
@@ -268,9 +268,26 @@ function OnboardingForm({ onStart }: OnboardingFormProps) {
 }
 
 function Stepper({ steps, current, stepProgress, onJump }: { steps: { id: string; label: string; }[]; current: number; stepProgress?: Record<string, number>; onJump?: (index: number) => void }) {
+  const navRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const nav = navRef.current;
+    if (!nav) return;
+    const active = nav.querySelector('.stepper-item.active') as HTMLElement | null;
+    if (active) {
+      // center the active item within the scroll container when possible
+      const navRect = nav.getBoundingClientRect();
+      const activeRect = active.getBoundingClientRect();
+      const navCenter = (navRect.left + navRect.right) / 2;
+      const activeCenter = (activeRect.left + activeRect.right) / 2;
+      const offset = activeCenter - navCenter;
+      nav.scrollBy({ left: offset, behavior: 'smooth' });
+    }
+  }, [current]);
   return (
     <div className="w-full py-4">
-      <nav className="stepper-nav flex items-center gap-4">
+      <nav ref={navRef} className="stepper-nav flex items-center gap-4">
         {steps.map((s, i) => {
           const active = i === current;
           const completed = (stepProgress && (stepProgress[s.id] || 0) >= 1) || i < current;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -395,6 +395,9 @@ input[type="range"]:focus::-webkit-slider-thumb {
   padding: 0 0.5rem;
   justify-content: center;
   position: relative; /* needed for connector line */
+  max-width: 100%;
+  align-items: flex-start !important;
+  width: auto;
 }
 .stepper-item:not(:last-child)::after {
   content: '';

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -465,17 +465,18 @@ input[type="range"]:focus::-webkit-slider-thumb {
 /* Mobile fixed header and fixed bottom navigation when stepper is active */
 .stepper-active .logo-container {
   position: fixed !important;
-  top: 8px !important;
+  top: calc(env(safe-area-inset-top, 0px) + 8px) !important;
   left: 50% !important;
   transform: translateX(-50%) !important;
   z-index: 9999 !important;
-  background: transparent !important;
+  background: rgba(255,255,255,0.0) !important;
   padding: 8px 0 !important;
+  pointer-events: auto !important;
 }
 
 .stepper-active .stepper-nav {
   position: fixed !important;
-  top: 64px !important; /* sits below logo */
+  top: calc(env(safe-area-inset-top, 0px) + 64px) !important; /* sits below logo and safe area */
   left: 0 !important;
   right: 0 !important;
   z-index: 9998 !important;
@@ -488,15 +489,15 @@ input[type="range"]:focus::-webkit-slider-thumb {
   gap: 0.75rem !important;
   background: transparent !important;
   justify-content: flex-start !important;
-  align-items: center !important;
+  align-items: flex-start !important;
 }
 
 /* hide scrollbars for the horizontal stepper */
 .stepper-active .stepper-nav::-webkit-scrollbar { display: none !important; }
 .stepper-active .stepper-nav { -ms-overflow-style: none !important; scrollbar-width: none !important; }
 
-/* add top padding to prevent content being hidden under fixed header */
-.stepper-active .container { padding-top: 140px !important; }
+/* add top padding to prevent content being hidden under fixed header; include safe-area inset */
+.stepper-active .container { padding-top: calc(env(safe-area-inset-top, 0px) + 140px) !important; }
 
 @media (max-width: 1024px) {
   /* on smaller screens ensure the stepper items appear horizontally and are scrollable */
@@ -506,18 +507,18 @@ input[type="range"]:focus::-webkit-slider-thumb {
 @media (max-width: 768px) {
   .stepper-active .sub-step-nav {
     position: fixed !important;
-    bottom: 0 !important;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 0px) !important;
     left: 0 !important;
     right: 0 !important;
     z-index: 10000 !important;
     background: #F9FAFB !important; /* gray-50 */
     box-shadow: 0 -6px 24px rgba(17,25,40,0.05) !important;
-    padding: 12px 16px !important;
+    padding: 12px 16px calc(env(safe-area-inset-bottom, 0px) + 12px) !important;
     display: flex !important;
     gap: 12px !important;
     justify-content: space-between !important;
     align-items: center !important;
   }
   /* ensure there is space at the bottom so content isn't hidden behind the fixed nav */
-  .stepper-active .container { padding-bottom: 112px !important; }
+  .stepper-active .container { padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 112px) !important; }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -452,3 +452,58 @@ input[type="range"]:focus::-webkit-slider-thumb {
 .progress-segment { flex:1; height:6px; background:#E5E7EB; border-radius:4px; position:relative; overflow:hidden; }
 .progress-segment .progress-inner { position:absolute; left:0; top:0; bottom:0; background:var(--primary); width:0%; transition:width .25s ease; }
 .progress-segment.active { /* fallback */ }
+
+/* Mobile fixed header and fixed bottom navigation when stepper is active */
+.stepper-active .logo-container {
+  position: fixed;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 60;
+  background: transparent;
+  padding: 8px 0;
+}
+
+.stepper-active .stepper-nav {
+  position: fixed;
+  top: 64px; /* sits below logo */
+  left: 0;
+  right: 0;
+  z-index: 55;
+  display: flex;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  white-space: nowrap;
+  flex-wrap: nowrap;
+  padding: 8px 16px;
+  gap: 0.75rem;
+  background: transparent;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+/* hide scrollbars for the horizontal stepper */
+.stepper-active .stepper-nav::-webkit-scrollbar { display: none; }
+.stepper-active .stepper-nav { -ms-overflow-style: none; scrollbar-width: none; }
+
+/* add top padding to prevent content being hidden under fixed header */
+.stepper-active .container { padding-top: 140px; }
+
+@media (max-width: 768px) {
+  .stepper-active .sub-step-nav {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 70;
+    background: #F9FAFB; /* gray-50 */
+    box-shadow: 0 -6px 24px rgba(17,25,40,0.05);
+    padding: 12px 16px;
+    display: flex;
+    gap: 12px;
+    justify-content: space-between;
+    align-items: center;
+  }
+  /* ensure there is space at the bottom so content isn't hidden behind the fixed nav */
+  .stepper-active .container { padding-bottom: 92px; }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -25,6 +25,12 @@ body {
   margin: 0; /* keep body margin reset, avoid resetting margins globally to preserve Tailwind spacing utilities */
 }
 
+/* Ensure root font-size makes 0.875rem (text-sm) >= 16px so mobile won't auto-zoom on form focus */
+html {
+  font-size: 18.285714px; /* 16 / 0.875 = 18.2857 -> so text-sm (0.875rem) becomes 16px; text-base becomes 18.2857px */
+  -webkit-text-size-adjust: 100%; /* prevent iOS from resizing text automatically */
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -455,55 +455,60 @@ input[type="range"]:focus::-webkit-slider-thumb {
 
 /* Mobile fixed header and fixed bottom navigation when stepper is active */
 .stepper-active .logo-container {
-  position: fixed;
-  top: 8px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 60;
-  background: transparent;
-  padding: 8px 0;
+  position: fixed !important;
+  top: 8px !important;
+  left: 50% !important;
+  transform: translateX(-50%) !important;
+  z-index: 9999 !important;
+  background: transparent !important;
+  padding: 8px 0 !important;
 }
 
 .stepper-active .stepper-nav {
-  position: fixed;
-  top: 64px; /* sits below logo */
-  left: 0;
-  right: 0;
-  z-index: 55;
-  display: flex;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  white-space: nowrap;
-  flex-wrap: nowrap;
-  padding: 8px 16px;
-  gap: 0.75rem;
-  background: transparent;
-  justify-content: flex-start;
-  align-items: center;
+  position: fixed !important;
+  top: 64px !important; /* sits below logo */
+  left: 0 !important;
+  right: 0 !important;
+  z-index: 9998 !important;
+  display: flex !important;
+  overflow-x: auto !important;
+  -webkit-overflow-scrolling: touch !important;
+  white-space: nowrap !important;
+  flex-wrap: nowrap !important;
+  padding: 8px 16px !important;
+  gap: 0.75rem !important;
+  background: transparent !important;
+  justify-content: flex-start !important;
+  align-items: center !important;
 }
 
 /* hide scrollbars for the horizontal stepper */
-.stepper-active .stepper-nav::-webkit-scrollbar { display: none; }
-.stepper-active .stepper-nav { -ms-overflow-style: none; scrollbar-width: none; }
+.stepper-active .stepper-nav::-webkit-scrollbar { display: none !important; }
+.stepper-active .stepper-nav { -ms-overflow-style: none !important; scrollbar-width: none !important; }
 
 /* add top padding to prevent content being hidden under fixed header */
-.stepper-active .container { padding-top: 140px; }
+.stepper-active .container { padding-top: 140px !important; }
+
+@media (max-width: 1024px) {
+  /* on smaller screens ensure the stepper items appear horizontally and are scrollable */
+  .stepper-active .stepper-nav { justify-content: flex-start !important; }
+}
 
 @media (max-width: 768px) {
   .stepper-active .sub-step-nav {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 70;
-    background: #F9FAFB; /* gray-50 */
-    box-shadow: 0 -6px 24px rgba(17,25,40,0.05);
-    padding: 12px 16px;
-    display: flex;
-    gap: 12px;
-    justify-content: space-between;
-    align-items: center;
+    position: fixed !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    z-index: 10000 !important;
+    background: #F9FAFB !important; /* gray-50 */
+    box-shadow: 0 -6px 24px rgba(17,25,40,0.05) !important;
+    padding: 12px 16px !important;
+    display: flex !important;
+    gap: 12px !important;
+    justify-content: space-between !important;
+    align-items: center !important;
   }
   /* ensure there is space at the bottom so content isn't hidden behind the fixed nav */
-  .stepper-active .container { padding-bottom: 92px; }
+  .stepper-active .container { padding-bottom: 112px !important; }
 }


### PR DESCRIPTION
## Purpose

The user wanted to improve the mobile experience by:
- Making the top logo and navigation steps fixed on mobile
- Creating horizontal scrollable navigation steps without visible scrollbars
- Adding fixed bottom navigation buttons with gray background and shadow
- Implementing auto-scroll to keep the current step in view
- Preventing mobile zoom when users interact with form elements
- Ensuring navigation elements are visible and not hidden under the browser's top bar

## Code changes

- **Fixed mobile layout**: Added CSS to make logo and stepper navigation fixed positioned on mobile with proper safe-area handling
- **Auto-scroll navigation**: Implemented useRef and useEffect to automatically scroll the active step into view within the horizontal navigation
- **Prevent mobile zoom**: Updated viewport meta tag and set root font-size to ensure all text is ≥16px to prevent iOS auto-zoom
- **Fixed bottom navigation**: Made sub-step navigation buttons fixed at bottom on mobile with gray-50 background and shadow
- **Horizontal scrolling**: Added overflow-x auto to stepper navigation with hidden scrollbars for smooth horizontal scrolling
- **Safe area support**: Used CSS env() for safe-area-inset to properly handle notched devices
- **Container padding**: Added appropriate top and bottom padding to prevent content from being hidden under fixed elementsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/22883c038bc048589cf92ad390a04aac/pixel-realm)

👀 [Preview Link](https://22883c038bc048589cf92ad390a04aac-pixel-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>22883c038bc048589cf92ad390a04aac</projectId>-->
<!--<branchName>pixel-realm</branchName>-->