### PR TITLE
Center navigation steps horizontally on desktop

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -490,7 +490,7 @@ input[type="range"]:focus::-webkit-slider-thumb {
   padding: 8px 16px !important;
   gap: 0.75rem !important;
   background: transparent !important;
-  justify-content: flex-start !important;
+  justify-content: center !important;
   align-items: flex-start !important;
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -450,6 +450,8 @@ input[type="range"]:focus::-webkit-slider-thumb {
     justify-content: center;
   }
   .stepper-item { min-width: 110px; height: 56px; }
+  /* Ensure centered alignment on desktop even when stepper is active/fixed */
+  .stepper-active .stepper-nav { justify-content: center !important; }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Purpose
Fix desktop navigation alignment by centering the stepper navigation horizontally instead of using flex-start alignment, improving the visual layout and user experience on desktop devices.

## Code changes
- Changed `.stepper-nav` justify-content from `flex-start` to `center` for desktop layout
- Added additional CSS rule to ensure centered alignment is maintained even when stepper is in active/fixed state
- Added explanatory comment for the new centering behaviorTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/22883c038bc048589cf92ad390a04aac/pulse-forge)

👀 [Preview Link](https://22883c038bc048589cf92ad390a04aac-pulse-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>22883c038bc048589cf92ad390a04aac</projectId>-->
<!--<branchName>pulse-forge</branchName>-->